### PR TITLE
Support building under the Clang Static Analyzer

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -24,8 +24,9 @@ variables.Add(PathVariable('IIGLUE', 'Path to iiglue executable', '/p/polyglot/p
 env = Environment(
     LLVM_ROOT=Dir('/p/polyglot/public/llvm/install'),
     tools=(
+        'default',              # load first, so others can override
         'bitcode',
-        'default',
+        'clang-analyzer',
         'expect',
         'iiglue',
         'plugin',

--- a/scons-tools/clang-analyzer.py
+++ b/scons-tools/clang-analyzer.py
@@ -1,0 +1,18 @@
+# Import and propagate environment variables to do the right thing if
+# scons is run under the Clang Static Analyzer, as in:
+#
+#   % scan-build [scan-build options] scons [scons options]
+#
+# Based on <http://stackoverflow.com/a/9305378/91929>.
+
+
+def generate(env):
+    from os import environ
+    if 'CCC_ANALYZER_OUTPUT_FORMAT' in environ:
+        env['CC'] = environ['CC']
+        env['CXX'] = environ['CXX']
+        env['ENV'].update(item for item in environ.iteritems() if item[0].startswith('CCC_'))
+
+
+def exists(env):
+    return True


### PR DESCRIPTION
`scan-build` is a wrapper script that applies the [Clang Static Analyzer](http://clang-analyzer.llvm.org/) to your code during compilation. It works by setting some environment variables (such as `$CXX`) to insert itself into the build process. That doesn't work by default with `scons`, though: `scons` creates its own new environment from scratch, ignoring the inherited environment entirely.

This group of changes includes logic to detect when `scan-build` is being used. If it is, we selectively import and propagate just the environment variables that are needed in order for `scan-build` to work as intended.

I'm please to report that the Analyzer's default checkers find nothing to complain about in our code as of now. Good!
