### PR TITLE
Allow running regression tests without iiglue

### DIFF
--- a/FindSentinels.cc
+++ b/FindSentinels.cc
@@ -301,8 +301,9 @@ void FindSentinels::print(raw_ostream &sink, const Module *module) const {
 			const BasicBlock &header = *check.first;
 			const ArgumentToBlockSet &entry = check.second;
 			for (const Argument &arg : iiglue.arrayArguments(func)) {
-				sink << "\tExamining " << arg.getName() << " in loop " << header.getName() << '\n';
 				const pair<BlockSet, bool> &checks = entry.at(&arg);
+				if (checks.first.empty()) continue;
+				sink << "\tExamining " << arg.getName() << " in loop " << header.getName() << '\n';
 				sink << "\t\tThere are " << checks.first.size() << " sentinel checks of this argument in this loop\n";
 				sink << "\t\t\tWe can" << (checks.second ? "" : "not") << " bypass all sentinel checks for this argument in this loop.\n";
 				const auto names =

--- a/NullAnnotator.cc
+++ b/NullAnnotator.cc
@@ -378,9 +378,10 @@ bool NullAnnotator::runOnModule(Module &module) {
 void NullAnnotator::print(raw_ostream &sink, const Module *module) const {
 	const IIGlueReader &iiglue = getAnalysis<IIGlueReader>();
 	for (const Function &func : *module) {
-		for (const Argument &arg : iiglue.arrayArguments(func)) {
-			sink << func.getName() << " with argument " << arg.getArgNo() << " should " << (annotate(arg) ? "" : "not ")
-			     << "be annotated NULL_TERMINATED (" << (getAnswer(arg)) << ").\n";
-		}
+		for (const Argument &arg : iiglue.arrayArguments(func))
+			if (annotate(arg))
+				sink << func.getName() << " with argument " << arg.getArgNo()
+				     << " should be annotated NULL_TERMINATED (" << (getAnswer(arg))
+				     << ").\n";
 	}
 }

--- a/SConstruct
+++ b/SConstruct
@@ -12,8 +12,12 @@ def pathIsExecutable(key, val, env):
     if not access(val, X_OK):
         raise SCons.Errors.UserError('Path for option %s is not executable: %s' % (key, val))
 
+def pathIsOptionalExecutable(key, val, env):
+    if val:
+        pathIsExecutable(key, val, env)
+
 variables = Variables(['.scons-options'], ARGUMENTS)
-variables.Add(PathVariable('IIGLUE', 'Path to iiglue executable', '/p/polyglot/public/bin/iiglue', pathIsExecutable))
+variables.Add(PathVariable('IIGLUE', 'Path to iiglue executable', '/p/polyglot/public/bin/iiglue', pathIsOptionalExecutable))
 
 default = WhereIs('llvm-config', (
     '/p/polyglot/public/bin',

--- a/scons-tools/plugin.py
+++ b/scons-tools/plugin.py
@@ -15,9 +15,11 @@ def __run_plugin_emitter(target, source, env):
 
 def __run_plugin_source_args(target, source, env, for_signature):
     def generate():
+        overreport = True
         for input in source:
             extension = splitext(input.name)[1]
             if extension == '.json':
+                overreport = False
                 yield '-iiglue-read-file'
                 yield input
             elif extension == '.so':
@@ -25,6 +27,8 @@ def __run_plugin_source_args(target, source, env, for_signature):
                 yield './%s' % input
             else:
                 yield input
+        if overreport:
+            yield '-overreport'
     return list(generate())
 
 

--- a/tests/SConscript
+++ b/tests/SConscript
@@ -9,12 +9,15 @@ env.AppendUnique(CLANG_FLAGS='-Werror')
 
 def RunTest(self, source, json=None, **kwargs):
     source = File(source)
+    actual = source.target_from_source('actualsAndExpecteds/', '.actual')
     bitcode = self.BitcodeSource(source)
-    if not json:
+
+    if self['IIGLUE'] and not json:
         json = source.target_from_source('json/', '.json')
         self.IIGlueAnalyze(json, bitcode)
-    actual = source.target_from_source('actualsAndExpecteds/', '.actual')
-    self.RunPlugin(actual, (bitcode, json), **kwargs)
+
+    pluginSources = (bitcode, json) if json else bitcode
+    self.RunPlugin(actual, pluginSources, **kwargs)
     passed = self.Expect(actual)
     Alias('test', passed)
 

--- a/tests/SConscript
+++ b/tests/SConscript
@@ -7,7 +7,7 @@ Import('env')
 env.AppendUnique(CLANG_FLAGS='-Werror')
 
 
-def RunTest(self, source, json=None, **kwargs):
+def RunTest(self, source, json=None, expected=None, **kwargs):
     source = File(source)
     actual = source.target_from_source('actualsAndExpecteds/', '.actual')
     bitcode = self.BitcodeSource(source)
@@ -37,9 +37,11 @@ env.AddMethod(RunTests)
 #
 
 tenv = env.Clone(PLUGIN_ARGS='-iiglue-reader')
-tenv.RunTest('iiglue-reader-peek.c')
 tenv.RunTest('iiglue-reader-variadic.c')
 tenv.RunTest('iiglue-reader-multiple.c', json=('json/iiglue-reader-peek.json', 'json/iiglue-reader-variadic.json'))
+
+if env['IIGLUE']:
+    tenv.RunTest('iiglue-reader-peek.c')
 
 
 ########################################################################

--- a/tests/sentinelCheckTests/actualsAndExpecteds/FindSentinelCheck13.expected
+++ b/tests/sentinelCheckTests/actualsAndExpecteds/FindSentinelCheck13.expected
@@ -12,7 +12,3 @@ Analyzing function: find
 			We cannot bypass all sentinel checks for this argument in this loop.
 		Sentinel checks: 
 			for.body
-	Examining string in loop for.cond3
-		There are 0 sentinel checks of this argument in this loop
-			We can bypass all sentinel checks for this argument in this loop.
-		Sentinel checks: 

--- a/tests/sentinelCheckTests/actualsAndExpecteds/FindSentinelCheck16.expected
+++ b/tests/sentinelCheckTests/actualsAndExpecteds/FindSentinelCheck16.expected
@@ -7,7 +7,3 @@ Analyzing function: print
 	We found: 0 loops
 Analyzing function: find
 	We found: 1 loops
-	Examining string in loop for.cond
-		There are 0 sentinel checks of this argument in this loop
-			We can bypass all sentinel checks for this argument in this loop.
-		Sentinel checks: 

--- a/tests/sentinelCheckTests/actualsAndExpecteds/FindSentinelCheck17.expected
+++ b/tests/sentinelCheckTests/actualsAndExpecteds/FindSentinelCheck17.expected
@@ -12,7 +12,3 @@ Analyzing function: find
 			We cannot bypass all sentinel checks for this argument in this loop.
 		Sentinel checks: 
 			for.body
-	Examining string2 in loop for.cond
-		There are 0 sentinel checks of this argument in this loop
-			We can bypass all sentinel checks for this argument in this loop.
-		Sentinel checks: 

--- a/tests/sentinelCheckTests/actualsAndExpecteds/FindSentinelCheck8.expected
+++ b/tests/sentinelCheckTests/actualsAndExpecteds/FindSentinelCheck8.expected
@@ -12,7 +12,3 @@ Analyzing function: find
 			We cannot bypass all sentinel checks for this argument in this loop.
 		Sentinel checks: 
 			for.body
-	Examining string in loop for.cond3
-		There are 0 sentinel checks of this argument in this loop
-			We can bypass all sentinel checks for this argument in this loop.
-		Sentinel checks: 

--- a/tests/sentinelCheckTests/actualsAndExpecteds/FindSentinelCheck9.expected
+++ b/tests/sentinelCheckTests/actualsAndExpecteds/FindSentinelCheck9.expected
@@ -16,7 +16,3 @@ Analyzing function: find
 			We cannot bypass all sentinel checks for this argument in this loop.
 		Sentinel checks: 
 			for.body
-	Examining string in loop for.cond3
-		There are 0 sentinel checks of this argument in this loop
-			We can bypass all sentinel checks for this argument in this loop.
-		Sentinel checks: 

--- a/tests/sentinelCheckTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck2.expected
+++ b/tests/sentinelCheckTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck2.expected
@@ -5,5 +5,4 @@ Pass::print not implemented for pass: 'Promote Memory to Register'!
 Printing analysis 'Promote Memory to Register' for function 'find':
 Pass::print not implemented for pass: 'Promote Memory to Register'!
 Printing analysis 'Determine whether and how to annotate each function with the null-terminated annotation':
-foo with argument 0 should not be annotated NULL_TERMINATED (0).
 find with argument 0 should be annotated NULL_TERMINATED (2).

--- a/tests/sentinelCheckTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck4.expected
+++ b/tests/sentinelCheckTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck4.expected
@@ -6,6 +6,4 @@ Printing analysis 'Promote Memory to Register' for function 'foo':
 Pass::print not implemented for pass: 'Promote Memory to Register'!
 Printing analysis 'Determine whether and how to annotate each function with the null-terminated annotation':
 find with argument 0 should be annotated NULL_TERMINATED (2).
-find with argument 1 should not be annotated NULL_TERMINATED (0).
-foo with argument 0 should not be annotated NULL_TERMINATED (0).
 foo with argument 1 should be annotated NULL_TERMINATED (2).

--- a/tests/sentinelCheckTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck5.expected
+++ b/tests/sentinelCheckTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck5.expected
@@ -5,5 +5,4 @@ Pass::print not implemented for pass: 'Promote Memory to Register'!
 Printing analysis 'Promote Memory to Register' for function 'find':
 Pass::print not implemented for pass: 'Promote Memory to Register'!
 Printing analysis 'Determine whether and how to annotate each function with the null-terminated annotation':
-foo with argument 0 should not be annotated NULL_TERMINATED (0).
 find with argument 0 should be annotated NULL_TERMINATED (2).

--- a/tests/sentinelCheckTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck6.expected
+++ b/tests/sentinelCheckTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck6.expected
@@ -6,6 +6,3 @@ Printing analysis 'Promote Memory to Register' for function 'foo':
 Pass::print not implemented for pass: 'Promote Memory to Register'!
 Printing analysis 'Determine whether and how to annotate each function with the null-terminated annotation':
 find with argument 0 should be annotated NULL_TERMINATED (2).
-find with argument 1 should not be annotated NULL_TERMINATED (0).
-foo with argument 0 should not be annotated NULL_TERMINATED (0).
-foo with argument 1 should not be annotated NULL_TERMINATED (0).

--- a/tests/sentinelCheckTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck7.expected
+++ b/tests/sentinelCheckTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck7.expected
@@ -5,7 +5,5 @@ Pass::print not implemented for pass: 'Promote Memory to Register'!
 Printing analysis 'Promote Memory to Register' for function 'foo':
 Pass::print not implemented for pass: 'Promote Memory to Register'!
 Printing analysis 'Determine whether and how to annotate each function with the null-terminated annotation':
-find with argument 0 should not be annotated NULL_TERMINATED (0).
 find with argument 1 should be annotated NULL_TERMINATED (2).
-foo with argument 0 should not be annotated NULL_TERMINATED (0).
 foo with argument 1 should be annotated NULL_TERMINATED (2).

--- a/tests/sentinelCheckTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck8.expected
+++ b/tests/sentinelCheckTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck8.expected
@@ -5,7 +5,5 @@ Pass::print not implemented for pass: 'Promote Memory to Register'!
 Printing analysis 'Promote Memory to Register' for function 'foo':
 Pass::print not implemented for pass: 'Promote Memory to Register'!
 Printing analysis 'Determine whether and how to annotate each function with the null-terminated annotation':
-find with argument 0 should not be annotated NULL_TERMINATED (0).
 find with argument 1 should be annotated NULL_TERMINATED (2).
-foo with argument 0 should not be annotated NULL_TERMINATED (0).
 foo with argument 1 should be annotated NULL_TERMINATED (2).

--- a/tests/sentinelCheckTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck9.expected
+++ b/tests/sentinelCheckTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck9.expected
@@ -5,5 +5,3 @@ Pass::print not implemented for pass: 'Promote Memory to Register'!
 Printing analysis 'Promote Memory to Register' for function 'foo':
 Pass::print not implemented for pass: 'Promote Memory to Register'!
 Printing analysis 'Determine whether and how to annotate each function with the null-terminated annotation':
-find with argument 1 should not be annotated NULL_TERMINATED (1).
-foo with argument 1 should not be annotated NULL_TERMINATED (0).


### PR DESCRIPTION
Our "-overwrite" mode lets us run analyses without iiglue by just assumng that every argument might be an array. This produces nearly identical results in practice. Furthermore, iiglue can be difficult or impossible to build, especially if one is using LLVM 3.5. So sometimes it can be convenient to work on this code base and run our regression tests using "-overwrite" instead of iiglue. The changes in this branch allow exactly that.