### PR TITLE
Regression test fixes for non-debug LLVM builds

### DIFF
--- a/AnnotatorHelper.cc
+++ b/AnnotatorHelper.cc
@@ -404,7 +404,7 @@ bool iterateOverModule(Module &module, const FunctionToValueSets &checkNullTermi
                             valueAnswer = processLoops(info.at(&func), value, valueToValueSet);
                             if (valueAnswer.type == SENTINEL_TERMINATED) {
                                 std::stringstream reason;
-                                reason << "found a non optional sentinel check for " << value->getName().str() << " in " << func.getName().str();
+                                reason << "found a non optional sentinel check in " << func.getName().str();
                                 reasons[*valueSet] = reason.str();
                             }
                             else if (valueAnswer.type == PARAMETER_LENGTH) {

--- a/AnnotatorHelper.cc
+++ b/AnnotatorHelper.cc
@@ -301,7 +301,6 @@ const Function &func, ValueSetSet &allValueSets) {
 			if (answer.type == formalAnswer.type && formalAnswer.type != NO_LENGTH_VALUE && formalAnswer.type != NOT_FIXED_LENGTH && answer.length == formalAnswer.length) {
 			    reason.str(" ");
 			    reason << " found a call to " << call.getCalledFunction()->getName().str();
-			    reason << " passing " << value->getName().str();
 			   // reason << " setting to " << answer.toString();
 			}
 		}

--- a/AnnotatorHelper.cc
+++ b/AnnotatorHelper.cc
@@ -201,9 +201,7 @@ struct ProcessStoresGEPVisitor : public InstVisitor<ProcessStoresGEPVisitor> {
             annotations[valueSet] = mergeAnswers(findAssociatedAnswer(pointer, annotations), old);
             if (old.type != annotations[valueSet].type || old.length != annotations[valueSet].length) {
                 std::stringstream reason;
-                reason << " pushed information from a store to ";
-                reason << pointer->getName().str();
-                reason << " from ";
+                reason << " pushed information from a store from ";
                 reason << value->getName().str();
                 reasons[*valueSet] = reason.str();
                 DEBUG(dbgs() << "Updating answer!\n");  

--- a/FindStructElements.cc
+++ b/FindStructElements.cc
@@ -128,12 +128,8 @@ void FindStructElements::print(raw_ostream &sink, const Module* ) const {
         for (unsigned i = 0; i < structTy->getNumElements(); i++) {
             pair<StructType*, int> p(structTy, i);
 	    const auto found(structElementCollections.find(p));
-	    if (found != structElementCollections.end()) {
-		    const ValueSet &values {*found->second};
-		    const std::multiset<const llvm::Value *, NameCompare> sortedValues {begin(values), end(values)};
-		    for (const auto inst : sortedValues)
-			    sink << "\telement " << i << " accessed at " << inst->getName() << "\n";
-	    }
+	    if (found != structElementCollections.end())
+	        sink << "\telement " << i << " accessed\n";
         }
         
     }

--- a/scons-tools/plugin.py
+++ b/scons-tools/plugin.py
@@ -41,7 +41,6 @@ __run_plugin_builder = Builder(
 	'env', 'HOME=' + environ['HOME'],
         './run',
         '-analyze',
-        '-debug',
         '$_RUN_PLUGIN_SOURCE_ARGS',
         '$PLUGIN_ARGS',
         '-test-$TEST=$TARGET',

--- a/tests/argumentSentinelCheckTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck1.expected
+++ b/tests/argumentSentinelCheckTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck1.expected
@@ -1,2 +1,2 @@
-foo with argument 0 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because  found a call to find passing string
 find with argument 0 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because found a non optional sentinel check for string in find
+foo with argument 0 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because  found a call to find

--- a/tests/argumentSentinelCheckTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck1.expected
+++ b/tests/argumentSentinelCheckTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck1.expected
@@ -1,2 +1,2 @@
-find with argument 0 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because found a non optional sentinel check for string in find
 foo with argument 0 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because  found a call to find
+find with argument 0 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because found a non optional sentinel check in find

--- a/tests/argumentSentinelCheckTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck10.expected
+++ b/tests/argumentSentinelCheckTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck10.expected
@@ -1,2 +1,2 @@
-find with argument 0 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because found a non optional sentinel check for string in find
+find with argument 0 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because found a non optional sentinel check in find
 foo with argument 1 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because  found a call to find

--- a/tests/argumentSentinelCheckTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck10.expected
+++ b/tests/argumentSentinelCheckTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck10.expected
@@ -1,2 +1,2 @@
 find with argument 0 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because found a non optional sentinel check for string in find
-foo with argument 1 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because  found a call to find passing string
+foo with argument 1 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because  found a call to find

--- a/tests/argumentSentinelCheckTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck2.expected
+++ b/tests/argumentSentinelCheckTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck2.expected
@@ -1,1 +1,1 @@
-find with argument 0 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because found a non optional sentinel check for string in find
+find with argument 0 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because found a non optional sentinel check in find

--- a/tests/argumentSentinelCheckTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck3.expected
+++ b/tests/argumentSentinelCheckTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck3.expected
@@ -1,4 +1,4 @@
-find with argument 0 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because found a non optional sentinel check for string in find
+find with argument 0 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because found a non optional sentinel check in find
 e with argument 0 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because  found a call to find
 d with argument 0 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because  found a call to e
 c with argument 0 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because  found a call to d

--- a/tests/argumentSentinelCheckTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck3.expected
+++ b/tests/argumentSentinelCheckTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck3.expected
@@ -1,6 +1,6 @@
 find with argument 0 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because found a non optional sentinel check for string in find
-e with argument 0 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because  found a call to find passing string
-d with argument 0 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because  found a call to e passing string
-c with argument 0 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because  found a call to d passing string
-b with argument 0 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because  found a call to c passing string
-a with argument 0 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because  found a call to b passing string
+e with argument 0 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because  found a call to find
+d with argument 0 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because  found a call to e
+c with argument 0 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because  found a call to d
+b with argument 0 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because  found a call to c
+a with argument 0 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because  found a call to b

--- a/tests/argumentSentinelCheckTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck4.expected
+++ b/tests/argumentSentinelCheckTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck4.expected
@@ -1,2 +1,2 @@
-find with argument 0 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because found a non optional sentinel check for string in find
+find with argument 0 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because found a non optional sentinel check in find
 foo with argument 1 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because  found a call to find

--- a/tests/argumentSentinelCheckTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck4.expected
+++ b/tests/argumentSentinelCheckTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck4.expected
@@ -1,2 +1,2 @@
 find with argument 0 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because found a non optional sentinel check for string in find
-foo with argument 1 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because  found a call to find passing string
+foo with argument 1 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because  found a call to find

--- a/tests/argumentSentinelCheckTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck5.expected
+++ b/tests/argumentSentinelCheckTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck5.expected
@@ -1,1 +1,1 @@
-find with argument 0 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because found a non optional sentinel check for string in find
+find with argument 0 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because found a non optional sentinel check in find

--- a/tests/argumentSentinelCheckTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck6.expected
+++ b/tests/argumentSentinelCheckTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck6.expected
@@ -1,1 +1,1 @@
-find with argument 0 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because found a non optional sentinel check for string in find
+find with argument 0 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because found a non optional sentinel check in find

--- a/tests/argumentSentinelCheckTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck7.expected
+++ b/tests/argumentSentinelCheckTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck7.expected
@@ -1,2 +1,2 @@
 find with argument 1 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because found a non optional sentinel check for string in find
-foo with argument 1 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because  found a call to find passing string
+foo with argument 1 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because  found a call to find

--- a/tests/argumentSentinelCheckTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck7.expected
+++ b/tests/argumentSentinelCheckTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck7.expected
@@ -1,2 +1,2 @@
-find with argument 1 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because found a non optional sentinel check for string in find
+find with argument 1 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because found a non optional sentinel check in find
 foo with argument 1 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because  found a call to find

--- a/tests/argumentSentinelCheckTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck8.expected
+++ b/tests/argumentSentinelCheckTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck8.expected
@@ -1,2 +1,2 @@
 find with argument 1 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because found a non optional sentinel check for string in find
-foo with argument 1 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because  found a call to find passing string
+foo with argument 1 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because  found a call to find

--- a/tests/argumentSentinelCheckTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck8.expected
+++ b/tests/argumentSentinelCheckTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck8.expected
@@ -1,2 +1,2 @@
-find with argument 1 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because found a non optional sentinel check for string in find
+find with argument 1 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because found a non optional sentinel check in find
 foo with argument 1 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because  found a call to find

--- a/tests/generic/actualsAndExpecteds/ExtraLoadSearching.expected
+++ b/tests/generic/actualsAndExpecteds/ExtraLoadSearching.expected
@@ -1,1 +1,1 @@
-find with argument 0 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because  found a call to find passing arg
+find with argument 0 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because  found a call to find

--- a/tests/generic/actualsAndExpecteds/structElementInFunctionCall.expected
+++ b/tests/generic/actualsAndExpecteds/structElementInFunctionCall.expected
@@ -1,2 +1,2 @@
 find with argument 0 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because found a non optional sentinel check for string in find
-struct struct.foo[0] should be annotated NULL_TERMINATED (Sentinel-terminated by 0) because  found a call to find passing string.
+struct struct.foo[0] should be annotated NULL_TERMINATED (Sentinel-terminated by 0) because  found a call to find.

--- a/tests/generic/actualsAndExpecteds/structElementInFunctionCall.expected
+++ b/tests/generic/actualsAndExpecteds/structElementInFunctionCall.expected
@@ -1,2 +1,2 @@
-find with argument 0 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because found a non optional sentinel check for string in find
+find with argument 0 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because found a non optional sentinel check in find
 struct struct.foo[0] should be annotated NULL_TERMINATED (Sentinel-terminated by 0) because  found a call to find.

--- a/tests/generic/actualsAndExpecteds/test.expected
+++ b/tests/generic/actualsAndExpecteds/test.expected
@@ -1,2 +1,2 @@
-setString with argument 1 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because  pushed information from a store to string1 from string
+setString with argument 1 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because  pushed information from a store from string
 struct struct.foo[0] should be annotated NULL_TERMINATED (Sentinel-terminated by 0) because found a non optional sentinel check in find.

--- a/tests/generic/actualsAndExpecteds/test.expected
+++ b/tests/generic/actualsAndExpecteds/test.expected
@@ -1,2 +1,2 @@
 setString with argument 1 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because  pushed information from a store to string1 from string
-struct struct.foo[0] should be annotated NULL_TERMINATED (Sentinel-terminated by 0) because found a non optional sentinel check for string in find.
+struct struct.foo[0] should be annotated NULL_TERMINATED (Sentinel-terminated by 0) because found a non optional sentinel check in find.

--- a/tests/lengthTests/SConscript
+++ b/tests/lengthTests/SConscript
@@ -4,7 +4,7 @@ env.RunTests(
     PLUGIN_ARGS=(
         '-mem2reg', '-no-pointer-comparisons', '-dce', '-mem2reg', '-redef',
         '-sra-annotator',
-        '-annotator', '-debug-only', '-find-length'
+        '-annotator',
     ),
     TEST='annotator',
 )

--- a/tests/lengthTests/actualsAndExpecteds/FixedLength6.expected
+++ b/tests/lengthTests/actualsAndExpecteds/FixedLength6.expected
@@ -1,2 +1,2 @@
-m_strlen with argument 0 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because found a non optional sentinel check for a in m_strlen
+m_strlen with argument 0 should be annotated NULL_TERMINATED (Sentinel-terminated by 0)  because found a non optional sentinel check in m_strlen
 foo with argument 0 should be annotated Parameter length of 1.

--- a/tests/structTests/actualsAndExpecteds/StructTest1.expected
+++ b/tests/structTests/actualsAndExpecteds/StructTest1.expected
@@ -1,4 +1,4 @@
 struct.bar:
-	element 1 accessed at x
-	element 2 accessed at y
-	element 3 accessed at z
+	element 1 accessed
+	element 2 accessed
+	element 3 accessed

--- a/tests/structTests/actualsAndExpecteds/StructTest2.expected
+++ b/tests/structTests/actualsAndExpecteds/StructTest2.expected
@@ -1,4 +1,4 @@
 struct.foo:
-	element 0 accessed at a
-	element 1 accessed at b
-	element 2 accessed at c
+	element 0 accessed
+	element 1 accessed
+	element 2 accessed

--- a/tests/structTests/actualsAndExpecteds/StructTest3.expected
+++ b/tests/structTests/actualsAndExpecteds/StructTest3.expected
@@ -1,9 +1,8 @@
 struct.foo:
-	element 0 accessed at a
-	element 0 accessed at a1
-	element 1 accessed at b2
+	element 0 accessed
+	element 1 accessed
 struct.bar:
-	element 0 accessed at first
-	element 1 accessed at x
-	element 2 accessed at y
-	element 3 accessed at z
+	element 0 accessed
+	element 1 accessed
+	element 2 accessed
+	element 3 accessed

--- a/tests/structTests/actualsAndExpecteds/StructTest5.expected
+++ b/tests/structTests/actualsAndExpecteds/StructTest5.expected
@@ -1,10 +1,9 @@
 struct.foo:
-	element 0 accessed at a
-	element 0 accessed at a10
-	element 1 accessed at b2
-	element 2 accessed at c
+	element 0 accessed
+	element 1 accessed
+	element 2 accessed
 struct.bar:
-	element 0 accessed at first
-	element 1 accessed at x
-	element 2 accessed at y
-	element 3 accessed at z
+	element 0 accessed
+	element 1 accessed
+	element 2 accessed
+	element 3 accessed

--- a/tests/structTests/actualsAndExpecteds/StructTest6.expected
+++ b/tests/structTests/actualsAndExpecteds/StructTest6.expected
@@ -1,21 +1,9 @@
 struct.bar:
-	element 0 accessed at first
-	element 0 accessed at first
-	element 1 accessed at x
-	element 1 accessed at x
-	element 1 accessed at x
-	element 2 accessed at y
-	element 2 accessed at y
-	element 2 accessed at y
-	element 3 accessed at z
-	element 3 accessed at z
-	element 3 accessed at z
+	element 0 accessed
+	element 1 accessed
+	element 2 accessed
+	element 3 accessed
 struct.foo:
-	element 0 accessed at a
-	element 0 accessed at a
-	element 0 accessed at a
-	element 0 accessed at a1
-	element 1 accessed at b
-	element 1 accessed at b2
-	element 1 accessed at b2
-	element 2 accessed at c
+	element 0 accessed
+	element 1 accessed
+	element 2 accessed

--- a/tests/structTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck1.expected
+++ b/tests/structTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck1.expected
@@ -1,1 +1,1 @@
-struct struct.foo[0] should be annotated NULL_TERMINATED (Sentinel-terminated by 0) because found a non optional sentinel check for string in find.
+struct struct.foo[0] should be annotated NULL_TERMINATED (Sentinel-terminated by 0) because found a non optional sentinel check in find.

--- a/tests/structTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck10.expected
+++ b/tests/structTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck10.expected
@@ -1,1 +1,1 @@
-struct struct.foo[0] should be annotated NULL_TERMINATED (Sentinel-terminated by 0) because found a non optional sentinel check for string in find.
+struct struct.foo[0] should be annotated NULL_TERMINATED (Sentinel-terminated by 0) because found a non optional sentinel check in find.

--- a/tests/structTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck2.expected
+++ b/tests/structTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck2.expected
@@ -1,1 +1,1 @@
-struct struct.foo[0] should be annotated NULL_TERMINATED (Sentinel-terminated by 0) because found a non optional sentinel check for string in find.
+struct struct.foo[0] should be annotated NULL_TERMINATED (Sentinel-terminated by 0) because found a non optional sentinel check in find.

--- a/tests/structTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck3.expected
+++ b/tests/structTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck3.expected
@@ -1,1 +1,1 @@
-struct struct.foo[0] should be annotated NULL_TERMINATED (Sentinel-terminated by 0) because found a non optional sentinel check for string in find.
+struct struct.foo[0] should be annotated NULL_TERMINATED (Sentinel-terminated by 0) because found a non optional sentinel check in find.

--- a/tests/structTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck4.expected
+++ b/tests/structTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck4.expected
@@ -1,1 +1,1 @@
-struct struct.foo[0] should be annotated NULL_TERMINATED (Sentinel-terminated by 0) because found a non optional sentinel check for string in find.
+struct struct.foo[0] should be annotated NULL_TERMINATED (Sentinel-terminated by 0) because found a non optional sentinel check in find.

--- a/tests/structTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck5.expected
+++ b/tests/structTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck5.expected
@@ -1,1 +1,1 @@
-struct struct.foo[0] should be annotated NULL_TERMINATED (Sentinel-terminated by 0) because found a non optional sentinel check for string in find.
+struct struct.foo[0] should be annotated NULL_TERMINATED (Sentinel-terminated by 0) because found a non optional sentinel check in find.

--- a/tests/structTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck6.expected
+++ b/tests/structTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck6.expected
@@ -1,1 +1,1 @@
-struct struct.foo[0] should be annotated NULL_TERMINATED (Sentinel-terminated by 0) because found a non optional sentinel check for string in find.
+struct struct.foo[0] should be annotated NULL_TERMINATED (Sentinel-terminated by 0) because found a non optional sentinel check in find.

--- a/tests/structTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck7.expected
+++ b/tests/structTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck7.expected
@@ -1,1 +1,1 @@
-struct struct.foo[0] should be annotated NULL_TERMINATED (Sentinel-terminated by 0) because found a non optional sentinel check for string in find.
+struct struct.foo[0] should be annotated NULL_TERMINATED (Sentinel-terminated by 0) because found a non optional sentinel check in find.

--- a/tests/structTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck8.expected
+++ b/tests/structTests/interproceduralTests/actualsAndExpecteds/InterproceduralCheck8.expected
@@ -1,1 +1,1 @@
-struct struct.foo[0] should be annotated NULL_TERMINATED (Sentinel-terminated by 0) because found a non optional sentinel check for string in find.
+struct struct.foo[0] should be annotated NULL_TERMINATED (Sentinel-terminated by 0) because found a non optional sentinel check in find.


### PR DESCRIPTION
Taken together, these changes let our regression tests pass when using non-debug-enabled LLVM builds, such as the standard Fedora `llvm` packages. That can save us a lot of time, since building our own debug-enabled LLVM takes about an hour. The down side, though, is that I had to remove several `llvm::Value` names from our tool’s explanatory output. That might make debugging harder, since we now have less transparency as to why the analysis does what it does.