### PR TITLE
Remove several unnecessary uses of `&*`

### DIFF
--- a/AnnotatorHelper.cc
+++ b/AnnotatorHelper.cc
@@ -227,7 +227,7 @@ const Function &func, ValueSetSet &allValueSets) {
 	for (const CallInst &call : calls | indirected) {
 		DEBUG(dbgs() << "About to iterate over the arguments to the call\n");
 		DEBUG(dbgs() << "Call: " << call.getName() << "\n");
-		const Function * calledFunction = &*call.getCalledFunction();
+		const Function * calledFunction = call.getCalledFunction();
 		DEBUG(dbgs() << "getCalledFunction name: " << calledFunction << "\n");
 		if (calledFunction == nullptr)
 			continue;
@@ -271,9 +271,9 @@ const Function &func, ValueSetSet &allValueSets) {
 			    if (symbolicLen >= 0) {
 			        DEBUG(dbgs() << "Trying to figure out the symbolic length information\n");
 			        DEBUG(dbgs() << "In function " << func.getName() << " calling " << calledFunction->getName() << "\n");
-			        ValueSetSet lengths = valueSetsReachingValue(*&*call.getArgOperand(symbolicLen), allValueSets);
+			        ValueSetSet lengths = valueSetsReachingValue(*call.getArgOperand(symbolicLen), allValueSets);
 			        if (lengths.size() == 1) {
-                        const ValueSet *length = &**lengths.begin();
+                        const ValueSet *length = *lengths.begin();
                         if (length == nullptr) {
                             DEBUG(dbgs() << "Unable to find a length, at least we know it's not fixed length\n");
                             formalAnswer = LengthInfo(NOT_FIXED_LENGTH,-1);
@@ -341,7 +341,7 @@ static LengthInfo processLoops(vector<LoopInformation> &LI, const Value* toCheck
 		LengthValueReport lengthResponse = findLengthChecks(loop, toCheck);
 	    if (lengthResponse.size() == 1) {
 	        DEBUG(dbgs() << "Found a symbolic length check in a loop!\n");
-	        const Value *length = &*(lengthResponse.begin()->first);
+	        const Value *length = lengthResponse.begin()->first;
 	        pair<BlockSet, bool> lengthInfo = lengthResponse[length];
 	        if (!lengthInfo.second) { //found a non-optional length check in some loop for toCheck
 	            const ValueSet *set = valueToValueSet.at(length);

--- a/CheckGetElementPtrVisitor.cc
+++ b/CheckGetElementPtrVisitor.cc
@@ -213,7 +213,7 @@ void CheckGetElementPtrVisitor::visitGetElementPtrInst(GetElementPtrInst& gepi) 
         //consistent way of thinking about it.
         //should probably look at how it's usually documented.
     }
-    Value *index = &*gepi.idx_begin()->get();
+    Value *index = gepi.idx_begin()->get();
     DEBUG(dbgs() << "About to get the range for " << *index << "\n");
     DEBUG(dbgs() << "\tAddress is " << index << "\n");
     SAGERange r = rangeAnalysis.getState(index);

--- a/FindSentinelHelper.cc
+++ b/FindSentinelHelper.cc
@@ -191,7 +191,7 @@ SentinelValueReport findSentinelChecks(const LoopInformation &loop, const Value 
 			    /*else if (const PHINode *phi = dyn_cast<PHINode>(pointer)) {
 			        bool foundSelf = false;
 			        for (const Value *in = phi->getIncomingValues()) {
-			            if (&*in == pointer) {
+			            if (in == pointer) {
 			                foundSelf = true;
 			            }
 			            if (valueReachesValue(*goal, *pointer) );

--- a/NoPointerArithmetic.cc
+++ b/NoPointerArithmetic.cc
@@ -94,7 +94,7 @@ namespace {
 								replacement->addIncoming(ConstantInt::get(tInt, 0), node->getIncomingBlock(argument));
 								replacement->addIncoming(BinaryOperator::Create(Instruction::Add, replacement, toAdd, "", oldAdd), node->getIncomingBlock(other));
 								GetElementPtrInst *gep = GetElementPtrInst::Create(&arg, ArrayRef<Value*>(replacement), 
-									"", &*node->getParent()->getFirstInsertionPt());
+									"", node->getParent()->getFirstInsertionPt());
 								errs() << "Replacing " << *node << "\n";
 								errs() << "With " << *replacement << "\n";
 								node->replaceAllUsesWith(gep);


### PR DESCRIPTION
In most normal situations, `&*p` is the same as just `p`.  Certainly that’s true when `p` is a simple pointer. These differ only when `p` is an iterator, in which case `&*p` is an idiomatic way to get a raw pointer to the same item that the iterator currently refers to.  But even this is rarely needed, as iterators have overloaded operators that let them do a pretty good job of pretending to be pointers.

Note that in two cases fixed in this commit, the redundant `&*` appeared as part of even longer chains of pointer-fiddling operations: one was `&**expr` and the other was `*&*expr`.  By the time you have that many `&` and `*` operations stacked up together, you really should stop and consider whether things have gotten out of hand. :smirk: